### PR TITLE
Join creation

### DIFF
--- a/src/app/counter/counter.component.ts
+++ b/src/app/counter/counter.component.ts
@@ -39,6 +39,7 @@ export class CounterComponent implements AfterViewInit {
       tap(() => console.log('test'))
     );
 
+    merge(of(1), of(2));
     // const piped2 = piped.pipe(map(x => 1));
 
     // piped.subscribe(x => console.log(x));

--- a/src/app/counter/counter.component.ts
+++ b/src/app/counter/counter.component.ts
@@ -39,7 +39,7 @@ export class CounterComponent implements AfterViewInit {
       tap(() => console.log('test'))
     );
 
-    merge(of(1), of(2));
+    merge(of(1), of(2)).subscribe(x =>  console.log(x));
     // const piped2 = piped.pipe(map(x => 1));
 
     // piped.subscribe(x => console.log(x));
@@ -51,6 +51,10 @@ export class CounterComponent implements AfterViewInit {
     //   merge(substract.pipe(map(() => -1))),  // map events from substract to -1 and merge with add stream.
     //   scan((acc, curr) => acc += curr)        // accumulate values.
     // ).subscribe(i => this.counter = i);
+
+    const subscribeTest = of(1);
+
+    subscribeTest.pipe(map(() => 2)).subscribe();
 
     merge(add.pipe(
       tap(null),

--- a/src/app/counter/counter.component.ts
+++ b/src/app/counter/counter.component.ts
@@ -26,6 +26,8 @@ export class CounterComponent implements AfterViewInit {
     const add = fromEvent(document.getElementById('addButton'), 'click');
     const substract = fromEvent(document.getElementById('minusButton'), 'click');
     const testIntervalAlfa = interval(1000);
+    const test = fromEvent(document.getElementById('addButton'), 'click');
+
 
     of(1).subscribe();
     of(2).pipe(map(() => 7)).subscribe();
@@ -55,6 +57,8 @@ export class CounterComponent implements AfterViewInit {
     const subscribeTest = of(1);
 
     subscribeTest.pipe(map(() => 2)).subscribe();
+
+    test.pipe(tap(null)).subscribe();
 
     merge(add.pipe(
       tap(null),

--- a/src/app/counter/counter.component.ts
+++ b/src/app/counter/counter.component.ts
@@ -60,3 +60,4 @@ export class CounterComponent implements AfterViewInit {
   }
 
 }
+

--- a/src/rxjs_wrapper.ts
+++ b/src/rxjs_wrapper.ts
@@ -96,7 +96,7 @@ export const wrapJoinCreationOperator = <T extends Array<any>, U>(
     fn: (...args: T) => U,
     metadata: JoinObservableMetadata
 ) => (...args: T) => {
-    console.log('Wrapped join creation operator.');
+    console.log(`Wrapped join creation operator. ${metadata.identifier} ${metadata.line}`);
     metadata.observables.map(observable => console.log(`with base observable ${observable}`));
     const message = createPayloadMessage(metadata, MessageType.joinObservable);
     sendToBackpage(message);

--- a/src/rxjs_wrapper.ts
+++ b/src/rxjs_wrapper.ts
@@ -127,7 +127,7 @@ export const wrapPipeableOperator = <T>(operatorFn: MonoTypeOperatorFunction<T>,
 
 // Wrap and return pipe statement.
 export const wrapPipe = <T>(source$: Observable<T>, metadata: PipeMetadata, ...operators: OperatorFunction<T, any>[]) => {
-    // console.log(`wrapped pipe identifier: ${metadata.identifier}  observable: ${metadata.observable} uuid: ${metadata.uuid}`);
+    console.log(`wrapped pipe line ${metadata.line} identifier: ${metadata.identifier}  observable: ${metadata.observable} uuid: ${metadata.uuid}`);
     // console.log(operators);
     const message = createPayloadMessage(metadata, MessageType.pipe);
     sendToBackpage(message);

--- a/src/rxjs_wrapper.ts
+++ b/src/rxjs_wrapper.ts
@@ -31,10 +31,12 @@ interface SubscribeEvent<T> {
     observable: string;
 }
 
-type Payload<T> = PipeMetadata | PipeableOperatorMetadata | ObservableMetadata | SubscriberMetadata | Event<T> | SubscribeEvent<T>;
+type Payload<T> = PipeMetadata | PipeableOperatorMetadata | ObservableMetadata | JoinObservableMetadata
+    | SubscriberMetadata | Event<T> | SubscribeEvent<T>;
 
 enum MessageType {
     observable = 'observable',
+    joinObservable = 'joinObservable',
     pipe = 'pipe',
     operator = 'operator',
     subscribe = 'subscribe',
@@ -95,6 +97,9 @@ export const wrapJoinCreationOperator = <T extends Array<any>, U>(
     metadata: JoinObservableMetadata
 ) => (...args: T) => {
     console.log('Wrapped join creation operator.');
+    metadata.observables.map(observable => console.log(`with base observable ${observable}`));
+    const message = createPayloadMessage(metadata, MessageType.joinObservable);
+    sendToBackpage(message);
     return fn(...args);
 };
 

--- a/src/rxjs_wrapper.ts
+++ b/src/rxjs_wrapper.ts
@@ -1,6 +1,8 @@
 import { Observable, MonoTypeOperatorFunction, Subscription, OperatorFunction } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
-import { PipeableOperatorMetadata, ObservableMetadata, PipeMetadata, SubscriberMetadata } from '../transformer/metadata';
+import {
+    PipeableOperatorMetadata, ObservableMetadata, PipeMetadata, SubscriberMetadata, JoinObservableMetadata
+} from '../transformer/metadata';
 import { pipeFromArray } from 'rxjs/internal/util/pipe';
 declare var chrome;
 
@@ -84,6 +86,15 @@ export const wrapCreationOperator = <T extends Array<any>, U>(fn: (...args: T) =
     console.log('Wrapped creation operator ', metadata.identifier, metadata.uuid);
     const message = createPayloadMessage(metadata, MessageType.observable);
     sendToBackpage(message);
+    return fn(...args);
+};
+
+// Wrap join creation operator and return it, send data to backpage.
+export const wrapJoinCreationOperator = <T extends Array<any>, U>(
+    fn: (...args: T) => U,
+    metadata: JoinObservableMetadata
+) => (...args: T) => {
+    console.log('Wrapped join creation operator.');
     return fn(...args);
 };
 

--- a/transformer/metadata.js
+++ b/transformer/metadata.js
@@ -66,7 +66,7 @@ exports.createJoinObservableMetadataExpression = function (node, call, variableN
     return ts.createObjectLiteral([
         createProperty('uuid', uuid),
         createProperty('type', node.getText()),
-        createProperty('observables', ts.createArrayLiteral(__spreadArrays(baseObservables))),
+        ts.createPropertyAssignment('observables', ts.createArrayLiteral(baseObservables)),
         createProperty('identifier', variableName),
         createProperty('file', file),
         createProperty('line', line)

--- a/transformer/metadata.js
+++ b/transformer/metadata.js
@@ -92,13 +92,12 @@ exports.createJoinObservableMetadataExpression = function (node, call, variableN
     ]);
 };
 // Traverse tree until observable is found.
-var getObservable = function (node, subscribe) {
-    if (subscribe === void 0) { subscribe = false; }
+var getObservable = function (node) {
     if (ts.isPropertyAccessExpression(node) || ts.isCallExpression(node)) {
-        return getObservable(node.expression, subscribe);
+        return getObservable(node.expression);
     }
     else if (ts.isIdentifier(node)) {
-        if (subscribe && ts.isPropertyAccessExpression(node.parent)) {
+        if (ts.isPropertyAccessExpression(node.parent)) {
             return namedObservables.get(node.getText());
         }
         return node;
@@ -177,7 +176,7 @@ var createArrayLiteralProperty = function (name, pipes) {
 // Create subscribe metadata object literal.
 exports.createSubscriberMetadataExpression = function (node) {
     var _a = exports.extractMetadata(node), file = _a.file, line = _a.line;
-    var observableMetadata = exports.extractMetadata(getObservable(node, true));
+    var observableMetadata = exports.extractMetadata(getObservable(node));
     var observableUUID = generateId(observableMetadata.file, observableMetadata.line, observableMetadata.pos);
     var pipes = createArrayLiteralProperty('pipes', getPipeArray(node));
     return ts.createObjectLiteral([

--- a/transformer/metadata.js
+++ b/transformer/metadata.js
@@ -46,7 +46,8 @@ var getBaseObservables = function (node) {
             if (ts.isCallExpression(argNode.parent)) { // Anonymous observable.
                 return null;
             }
-            return argNode.getText();
+            var _a = exports.extractMetadata(namedObservables.get(argNode.getText())), file = _a.file, line = _a.line, pos = _a.pos;
+            return generateId(file, line, pos);
         }
     };
     var observables = node.arguments

--- a/transformer/metadata.ts
+++ b/transformer/metadata.ts
@@ -97,7 +97,8 @@ const getBaseObservables = (node: ts.CallExpression): Array<string> => {
             if (ts.isCallExpression(argNode.parent)) {  // Anonymous observable.
                 return null;
             }
-            return argNode.getText();
+            const { file, line, pos } = extractMetadata(namedObservables.get(argNode.getText()));
+            return generateId(file, line, pos);
         }
     };
 

--- a/transformer/metadata.ts
+++ b/transformer/metadata.ts
@@ -10,6 +10,16 @@ export interface ObservableMetadata {
     pos?: number;
 }
 
+export interface JoinObservableMetadata {
+    uuid: string;
+    type?: string;
+    observables: Array<string>;
+    identifier: string;
+    file: string;
+    line: number;
+    pos?: number;
+}
+
 export interface PipeMetadata {
     uuid: string;
     observable: string;
@@ -107,7 +117,7 @@ export const createJoinObservableMetadataExpression = (
     return ts.createObjectLiteral([
         createProperty('uuid', uuid),
         createProperty('type', node.getText()),
-        createProperty('observables', ts.createArrayLiteral([...baseObservables])),
+        ts.createPropertyAssignment('observables', ts.createArrayLiteral(baseObservables)),
         createProperty('identifier', variableName),
         createProperty('file', file),
         createProperty('line', line)

--- a/transformer/metadata.ts
+++ b/transformer/metadata.ts
@@ -161,11 +161,11 @@ export const createJoinObservableMetadataExpression = (
 };
 
 // Traverse tree until observable is found.
-const getObservable = (node: ts.Expression, subscribe = false): ts.Identifier => {
+const getObservable = (node: ts.Expression): ts.Identifier => {
     if (ts.isPropertyAccessExpression(node) || ts.isCallExpression(node)) {
-        return getObservable(node.expression, subscribe);
+        return getObservable(node.expression);
     } else if (ts.isIdentifier(node)) {
-        if (subscribe && ts.isPropertyAccessExpression(node.parent)) {
+        if (ts.isPropertyAccessExpression(node.parent)) {
             return namedObservables.get(node.getText());
         }
         return node;
@@ -269,7 +269,7 @@ const createArrayLiteralProperty = (name: string, pipes: Array<Pipe>): ts.Proper
 // Create subscribe metadata object literal.
 export const createSubscriberMetadataExpression = (node: ts.CallExpression): ts.ObjectLiteralExpression => {
     const { file, line } = extractMetadata(node);
-    const observableMetadata = extractMetadata(getObservable(node, true));
+    const observableMetadata = extractMetadata(getObservable(node));
     const observableUUID = generateId(observableMetadata.file, observableMetadata.line, observableMetadata.pos);
     const pipes = createArrayLiteralProperty('pipes', getPipeArray(node));
 

--- a/transformer/node_dispatcher.js
+++ b/transformer/node_dispatcher.js
@@ -52,6 +52,9 @@ var classify = function (node) {
     if (isRxJSCreationOperator(node)) {
         classification = 'RXJS_CREATION_OPERATOR';
     }
+    else if (isRxJSJoinCreationOperator(node)) {
+        classification = 'RXJS_JOIN_CREATION_OPERATOR';
+    }
     else if (isPipePropertyAccessExpr(node)) {
         classification = 'RXJS_PIPE';
     }
@@ -69,6 +72,9 @@ exports.dispatchNode = function (node) {
         case 'RXJS_CREATION_OPERATOR':
             node = operator_wrapper_1.createWrapCreationExpression(node);
             return [node, 'wrapCreationOperator'];
+        case 'RXJS_JOIN_CREATION_OPERATOR':
+            node = operator_wrapper_1.createWrapJoinCreationExpression(node);
+            return [node, 'wrapJoinCreationOperator'];
         case 'RXJS_PIPE':
             node = operator_wrapper_1.wrapPipeStatement(node);
             return [node, 'wrapPipe'];

--- a/transformer/node_dispatcher.js
+++ b/transformer/node_dispatcher.js
@@ -9,7 +9,14 @@ var rxjsJoinCreationOperators = ['combineLatest', 'concat', 'forkJoin', 'merge',
 var isRxJSCreationOperator = function (node) {
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.getSourceFile() !== undefined) {
         return rxjsCreationOperators
-            .concat(rxjsJoinCreationOperators)
+            .some(function (operator) { return operator === node.expression.getText(); });
+    }
+    return false;
+};
+// Determine if given node is RxJS Join Creation Operator Statement.
+var isRxJSJoinCreationOperator = function (node) {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.getSourceFile() !== undefined) {
+        return rxjsJoinCreationOperators
             .some(function (operator) { return operator === node.expression.getText(); });
     }
     return false;

--- a/transformer/node_dispatcher.ts
+++ b/transformer/node_dispatcher.ts
@@ -1,5 +1,5 @@
 import * as ts from 'typescript';
-import { createWrapCreationExpression, wrapSubscribeMethod, wrapPipeStatement } from './operator_wrapper';
+import { createWrapCreationExpression, createWrapJoinCreationExpression, wrapSubscribeMethod, wrapPipeStatement } from './operator_wrapper';
 
 const rxjsCreationOperators = ['ajax', 'bindCallback', 'bindNodeCallback', 'defer', 'empty', 'from', 'fromEvent',
     'fromEventPattern', 'generate', 'interval', 'of', 'range', 'throwError', 'timer', 'iif'];
@@ -61,6 +61,8 @@ const classify = (node: ts.Node): NodeType => {
 
     if (isRxJSCreationOperator(node)) {
         classification = 'RXJS_CREATION_OPERATOR';
+    } else if (isRxJSJoinCreationOperator(node)) {
+        classification = 'RXJS_JOIN_CREATION_OPERATOR';
     } else if (isPipePropertyAccessExpr(node)) {
         classification = 'RXJS_PIPE';
     } else if (isSubscribeStatement(node)) {
@@ -80,6 +82,9 @@ export const dispatchNode = (node: ts.Node): [ts.Node, string | null] => {
         case 'RXJS_CREATION_OPERATOR':
             node = createWrapCreationExpression(node as ts.CallExpression);
             return [node, 'wrapCreationOperator'];
+        case 'RXJS_JOIN_CREATION_OPERATOR':
+            node = createWrapJoinCreationExpression(node as ts.CallExpression);
+            return [node, 'wrapJoinCreationOperator'];
         case 'RXJS_PIPE':
             node = wrapPipeStatement(node as ts.CallExpression);
             return [node, 'wrapPipe'];

--- a/transformer/node_dispatcher.ts
+++ b/transformer/node_dispatcher.ts
@@ -12,7 +12,15 @@ type NodeType = 'UNCLASSIFIED' | 'RXJS_CREATION_OPERATOR' | 'RXJS_JOIN_CREATION_
 const isRxJSCreationOperator = (node: ts.Node): boolean => {
     if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.getSourceFile() !== undefined) {
         return rxjsCreationOperators
-            .concat(rxjsJoinCreationOperators)
+            .some(operator => operator === node.expression.getText());
+    }
+    return false;
+};
+
+// Determine if given node is RxJS Join Creation Operator Statement.
+const isRxJSJoinCreationOperator = (node: ts.Node): boolean => {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.getSourceFile() !== undefined) {
+        return rxjsJoinCreationOperators
             .some(operator => operator === node.expression.getText());
     }
     return false;

--- a/transformer/operator_wrapper.js
+++ b/transformer/operator_wrapper.js
@@ -28,6 +28,15 @@ exports.createWrapCreationExpression = function (node) {
     var completeCall = ts.createCall(curriedCall, undefined, node.arguments);
     return completeCall;
 };
+// Create wrapped RxJS join creation operator expression.
+exports.createWrapJoinCreationExpression = function (node) {
+    var identifier = node.expression;
+    var variableName = ts.isVariableDeclaration(node.parent)
+        ? node.parent.name.getText()
+        : 'anonymous';
+    var metaDataExpression = metadata_1.createJoinObservableMetadataExpression(identifier, node, variableName);
+    return node; // TODO: return mutated node.
+};
 // Wrap array of pipeable operators.
 var wrapPipeableOperatorArray = function (args, pipeUUID, observableUUID) {
     if (!args.every(function (operator) { return ts.isCallExpression(operator); })) {

--- a/transformer/operator_wrapper.js
+++ b/transformer/operator_wrapper.js
@@ -35,7 +35,9 @@ exports.createWrapJoinCreationExpression = function (node) {
         ? node.parent.name.getText()
         : 'anonymous';
     var metaDataExpression = metadata_1.createJoinObservableMetadataExpression(identifier, node, variableName);
-    return node; // TODO: return mutated node.
+    var curriedCall = createWrappedCallExpression('wrapJoinCreationOperator', identifier.getText(), [metaDataExpression]);
+    var completeCall = ts.createCall(curriedCall, undefined, node.arguments);
+    return completeCall;
 };
 // Wrap array of pipeable operators.
 var wrapPipeableOperatorArray = function (args, pipeUUID, observableUUID) {

--- a/transformer/operator_wrapper.ts
+++ b/transformer/operator_wrapper.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import {
   createPipeableOperatorMetadataExpression, createObservableMetadataExpression,
-  createSubscriberMetadataExpression, createPipeMetadataExpression
+  createSubscriberMetadataExpression, createPipeMetadataExpression, createJoinObservableMetadataExpression
 } from './metadata';
 import * as uuid from 'uuid/v4';
 
@@ -25,6 +25,16 @@ export const createWrapCreationExpression = (node: ts.CallExpression): ts.CallEx
   const curriedCall = createWrappedCallExpression('wrapCreationOperator', identifier.getText(), [metaDataExpression]);
   const completeCall = ts.createCall(curriedCall, undefined, node.arguments);
   return completeCall;
+};
+
+// Create wrapped RxJS join creation operator expression.
+export const createWrapJoinCreationExpression = (node: ts.CallExpression): ts.CallExpression => {
+  const identifier: ts.Identifier = node.expression as ts.Identifier;
+  const variableName = ts.isVariableDeclaration(node.parent)
+    ? node.parent.name.getText()
+    : 'anonymous';
+  const metaDataExpression = createJoinObservableMetadataExpression(identifier, node, variableName);
+  return node; // TODO: return mutated node.
 };
 
 // Wrap array of pipeable operators.

--- a/transformer/operator_wrapper.ts
+++ b/transformer/operator_wrapper.ts
@@ -79,7 +79,7 @@ export const wrapPipeStatement = (node: ts.CallExpression): ts.CallExpression =>
 export const wrapSubscribeMethod = (node: ts.CallExpression): ts.CallExpression => {
   const args = node.arguments.map(arg => arg);  // ts.NodeArray => array.
   const propertyAccessExpr = node.expression as ts.PropertyAccessExpression;
-  const source$ = propertyAccessExpr.expression;
+  const source$: ts.Identifier = propertyAccessExpr.expression as ts.Identifier;
   const metadata = createSubscriberMetadataExpression(node);
 
   return ts.createCall(ts.createIdentifier('wrapSubscribe'), undefined, [source$, metadata, ...args]);

--- a/transformer/operator_wrapper.ts
+++ b/transformer/operator_wrapper.ts
@@ -34,7 +34,9 @@ export const createWrapJoinCreationExpression = (node: ts.CallExpression): ts.Ca
     ? node.parent.name.getText()
     : 'anonymous';
   const metaDataExpression = createJoinObservableMetadataExpression(identifier, node, variableName);
-  return node; // TODO: return mutated node.
+  const curriedCall = createWrappedCallExpression('wrapJoinCreationOperator', identifier.getText(), [metaDataExpression]);
+  const completeCall = ts.createCall(curriedCall, undefined, node.arguments);
+  return completeCall;
 };
 
 // Wrap array of pipeable operators.


### PR DESCRIPTION
RxJS Merge observables now wrapped.

RxJS observables created by RxJS join operators where not replaced by wrapped versions, now they are. Base observables and merge observable data is sent to backpage to be displayed in the devtools extension GUI.